### PR TITLE
Removed the overlapping in the navbar so that user can easily navigate

### DIFF
--- a/frontend/src/css/components/navbar.css
+++ b/frontend/src/css/components/navbar.css
@@ -186,7 +186,7 @@
     align-items: flex-start;
     justify-content: flex-start;
     padding: 100px 30px 30px;
-    gap: 5px;
+    gap: 20px;
     transition: var(--transition-slow);
     box-shadow: -10px 0 40px rgba(0, 0, 0, 0.3);
   }
@@ -197,7 +197,7 @@
 
   .nav-link {
     width: 100%;
-    padding: 15px 20px;
+    padding: 10px 20px;
     font-size: 1rem;
   }
 


### PR DESCRIPTION
## Which issue does this PR close?

-Closes Navbar overlapping in mobile #70

## What changes are included in this PR?
Removed the overlapping in the navbar so that user can easily navigate without misclicking


<img width="757" height="852" alt="image" src="https://github.com/user-attachments/assets/f898c428-923a-4d1c-bfa6-d94f022e60a1" />


