### PR TITLE
Navbar overlapping and Hamburger visibility

### DIFF
--- a/frontend/src/css/components/navbar.css
+++ b/frontend/src/css/components/navbar.css
@@ -171,7 +171,7 @@
 }
 
 @media (max-width: 1024px) {
-  .nav-toggle {
+   .nav-toggle {
     display: flex;
   }
 
@@ -183,8 +183,8 @@
     height: 100vh;
     background: var(--gradient-primary);
     flex-direction: column;
-    align-items: flex-start;
-    justify-content: flex-start;
+    align-items: center;
+    justify-content: center;
     padding: 100px 30px 30px;
     gap: 20px;
     transition: var(--transition-slow);

--- a/frontend/src/css/style.css
+++ b/frontend/src/css/style.css
@@ -392,3 +392,8 @@ select {
     padding: 6px 15px;
   }
 }
+
+html,
+body {
+  overflow-x: hidden;
+}


### PR DESCRIPTION
## Which issue does this PR close?

Closes Navbar overlapping in mobile #70


## What changes are included in this PR?
Now the elements of navbar in mobile resolution doesn't overlap and the visiblity of the hamburger for the navbar is 
now solved, this solves a major UI issue for the mobile screens

<img width="671" height="768" alt="image" src="https://github.com/user-attachments/assets/3040e64d-b490-4a8b-83e6-1dd36ff81d96" />

<img width="1030" height="837" alt="Screenshot 2026-01-02 144312" src="https://github.com/user-attachments/assets/00bf9739-87d3-4422-8c63-7bb57d1ea35f" />
<img width="700" height="822" alt="Screenshot 2026-01-02 144317" src="https://github.com/user-attachments/assets/dc63144d-367a-41f7-91cc-469556c7462d" />

## Are these changes tested?
Yes all the changes have been tested 


