### PR TITLE
🐛 Fix: Center CTA Buttons on Mobile Screens

### DIFF
--- a/frontend/src/css/components/hero.css
+++ b/frontend/src/css/components/hero.css
@@ -381,6 +381,7 @@
 
   .hero-cta {
     flex-direction: column;
+    align-items: center;
     gap: 15px;
   }
 


### PR DESCRIPTION
## **Which issue does this PR close?**

**Closes #96**

---

## **Rationale for this change**

On smaller screen sizes, the **“Get Started”** and **“Learn More”** buttons were not aligned with the rest of the centered content.  
This caused visual inconsistency and reduced usability on mobile devices.

Center-aligning these buttons ensures a cleaner, more predictable layout and improves the overall mobile user experience.

---

## **What changes are included in this PR?**

- Updated responsive layout styles to center **Get Started** and **Learn More** buttons on mobile viewports
- Applied mobile-first alignment rules without affecting tablet or desktop layouts
- Ensured consistency with existing centered elements in small-width screens

---

## **Are these changes tested?**

**Yes.**

- Tested using browser DevTools in mobile viewports (375px, 425px, 768px)
- Verified behavior on both Android and iOS emulation
- Confirmed no regression in desktop and tablet layouts

_No additional automated tests were added as this change is purely a UI alignment fix and is covered by existing layout behavior._

---

## **Are there any user-facing changes?**

**Yes.**

- Buttons are now visually centered on mobile devices
- Improved visual consistency and usability for small-screen users

No documentation changes are required since this is a minor UI improvement.

---

## **Screenshots (**

### **Before**
_Misaligned buttons on mobile view_

<img width="777" height="760" alt="Before - misaligned buttons" src="https://github.com/user-attachments/assets/53d48ab1-67c3-41da-9335-2151b28cb0de" />

### **After**
_Centered buttons consistent with the rest of the layout_

<img width="1920" height="1200" alt="After - centered buttons" src="https://github.com/user-attachments/assets/3e9b036a-5244-4d27-b92a-b4d24bed2dd5" />

---

## **✅ Checklist**

- [x] Bug reproduced and fixed
- [x] Responsive behavior verified
- [x] No breaking changes
- [x] Code follows existing style conventions
