### PR TITLE
Fix Start Quiz Now button navigation in Kids Quiz Zone

### DIFF
--- a/frontend/src/index.html
+++ b/frontend/src/index.html
@@ -839,7 +839,7 @@
               </div>
             </div>
 
-            <a href="quiz.html" class="quiz-btn">
+            <a href="pages/quiz.html" class="quiz-btn">
               <i class="fa-solid fa-play"></i> Start Quiz Now
             </a>
           </div>


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #116 

## Rationale for this change

The “Start Quiz Now” button on the Kids Quiz Zone page was not redirecting users
to the quiz page due to an incorrect or missing link path. This change fixes the
navigation issue and restores the expected behavior.

## What changes are included in this PR?

- Corrected the `href` path for the “Start Quiz Now” button
- Ensured proper redirection to the quiz page

## Are these changes tested?

- Yes, manually tested by clicking the button and confirming successful
  redirection to the quiz page.

## Are there any user-facing changes?

- Yes. Users can now navigate to the quiz page by clicking the
  “Start Quiz Now” button.

## Screenshots 

before
<img width="1226" height="604" alt="image" src="https://github.com/user-attachments/assets/bebd21ac-b120-4620-b9d9-a37843838b72" />

after
<img width="1431" height="617" alt="image" src="https://github.com/user-attachments/assets/833ce32d-bfc6-4d88-9ea3-9500db392a84" />



