### PR TITLE
Fix scroll indicator alignment in hero section

### DIFF
--- a/frontend/src/css/components/hero.css
+++ b/frontend/src/css/components/hero.css
@@ -262,8 +262,8 @@
 .scroll-indicator {
   position: absolute;
   bottom: 60px;
-  left: 50%;
-  transform: translateX(-50%);
+  width: 100%;
+  justify-content: center;
   display: flex;
   flex-direction: column;
   align-items: center;


### PR DESCRIPTION
## What does this PR do?

This PR fixes the alignment issue of the scroll-down indicator in the hero section. The indicator was shifting toward the corner instead of staying centered due to conflicting layout styles.

issue [link](https://github.com/Jagrati3/Environment_Animal_Safety_Hub/issues/200)

### What was the problem?
The scroll indicator had unnecessary full-width styling combined with centering transforms, which caused it to move away from the center on desktop screens.

## How is it fixed?

- 1. Removed the unnecessary `width: 100%` from the scroll indicator
- 2. Kept` left: 50%` with `transform: translateX(-50%) `for proper centering
- 3. Ensured the indicator stays centered across desktop viewports

### Result

- Scroll indicator is now perfectly centered
- No layout shifts or visual glitches
- Clean and responsive behavior maintained


### Screenshots

before :
<img width="2879" height="1631" alt="image" src="https://github.com/user-attachments/assets/0ebce399-a66a-443d-8804-e2fa94c2d5bd" />

after:
<img width="2855" height="1559" alt="image" src="https://github.com/user-attachments/assets/bc747aea-964a-46f5-b9cb-1263aae924d5" />
