### PR TITLE
Add dedicated Myth vs Fact page and expand awareness content

### DIFF
--- a/frontend/src/pages/myth-vs-fact.html
+++ b/frontend/src/pages/myth-vs-fact.html
@@ -1,0 +1,361 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>Myth vs Fact | EcoLife</title>
+
+<link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600;700&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css">
+
+<style>
+:root{
+  --green:#2e7d32;
+  --light:#e8f5e9;
+  --shadow:0 20px 40px rgba(0,0,0,0.15);
+}
+
+*{
+  box-sizing:border-box;
+  font-family:"Poppins",sans-serif;
+}
+
+body{
+  margin:0;
+  background:#f4fbf6;
+  color:#1a1a1a;
+}
+
+/* HERO */
+.hero{
+  padding:90px 20px 70px;
+  text-align:center;
+  background:linear-gradient(135deg,#1b5e20,#2e7d32,#388e3c);
+  color:white;
+  border-bottom-left-radius:40px;
+  border-bottom-right-radius:40px;
+}
+
+.hero h1{font-size:3rem;}
+.hero p{opacity:.9;}
+
+/* SECTION */
+.section{
+  max-width:1200px;
+  margin:50px auto 80px;
+  padding:20px;
+}
+
+.section-header{
+  text-align:center;
+  margin-bottom:50px;
+}
+
+.section-header h2{
+  font-size:2.5rem;
+  color:var(--green);
+}
+
+/* GRID */
+.myth-fact-grid{
+  display:grid;
+  grid-template-columns:repeat(auto-fit,minmax(260px,1fr));
+  gap:30px;
+}
+
+/* CARD */
+.myth-card-wrapper{perspective:1000px;}
+
+.myth-card{
+  position:relative;
+  height:320px;
+  transform-style:preserve-3d;
+  transition:transform .7s ease;
+  cursor:pointer;
+}
+
+.myth-card.flipped{transform:rotateY(180deg);}
+
+.card-face{
+  position:absolute;
+  inset:0;
+  backface-visibility:hidden;
+  background:white;
+  border-radius:22px;
+  box-shadow:var(--shadow);
+  display:flex;
+  align-items:center;
+  justify-content:center;
+  text-align:center;
+  padding:30px;
+}
+
+.card-back{
+  transform:rotateY(180deg);
+  background:var(--light);
+}
+
+.icon-box{
+  font-size:3rem;
+  margin-bottom:15px;
+}
+
+.myth-icon{color:#d32f2f;}
+.fact-icon{color:var(--green);}
+
+.action-pill{
+  margin-top:20px;
+  padding:8px 16px;
+  background:var(--green);
+  color:white;
+  border-radius:30px;
+  font-size:.9rem;
+  display:inline-block;
+}
+
+/* BACK BUTTON */
+.back-wrapper{
+  display:flex;
+  justify-content:center;
+  margin-top:60px;
+}
+
+.back-btn{
+  padding:12px 30px;
+  background:var(--green);
+  color:white;
+  border:none;
+  border-radius:30px;
+  font-size:1rem;
+  cursor:pointer;
+  transition:.3s;
+}
+
+.back-btn:hover{
+  background:#1b5e20;
+  transform:translateY(-3px);
+  box-shadow:0 10px 25px rgba(46,125,50,.35);
+}
+
+footer{
+  text-align:center;
+  padding:20px;
+  color:#666;
+}
+</style>
+</head>
+
+<body>
+
+<section class="hero">
+  <h1>🌱 Myth vs Fact</h1>
+  <p>Break environmental myths • Learn the real truth</p>
+</section>
+
+<section class="section">
+ 
+
+  <div class="myth-fact-grid">
+
+    <!-- CARD 1 -->
+    <div class="myth-card-wrapper">
+      <div class="myth-card" onclick="this.classList.toggle('flipped')">
+        <div class="card-face">
+          <div>
+            <div class="icon-box myth-icon"><i class="fa-solid fa-recycle"></i></div>
+            <h3>Myth</h3>
+            <p>Plastic is fully recyclable</p>
+            <div class="action-pill">Reveal Truth</div>
+          </div>
+        </div>
+        <div class="card-face card-back">
+          <div>
+            <div class="icon-box fact-icon"><i class="fa-solid fa-earth-americas"></i></div>
+            <h3>Fact</h3>
+            <p>Only ~9% of plastic is recycled. Reduce & reuse is key.</p>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- CARD 2 -->
+    <div class="myth-card-wrapper">
+      <div class="myth-card" onclick="this.classList.toggle('flipped')">
+        <div class="card-face">
+          <div>
+            <div class="icon-box myth-icon"><i class="fa-solid fa-temperature-arrow-up"></i></div>
+            <h3>Myth</h3>
+            <p>Climate change is natural</p>
+            <div class="action-pill">Reveal Truth</div>
+          </div>
+        </div>
+        <div class="card-face card-back">
+          <div>
+            <div class="icon-box fact-icon"><i class="fa-solid fa-smog"></i></div>
+            <h3>Fact</h3>
+            <p>Human activities are the main cause of rapid warming.</p>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- CARD 3 -->
+    <div class="myth-card-wrapper">
+      <div class="myth-card" onclick="this.classList.toggle('flipped')">
+        <div class="card-face">
+          <div>
+            <div class="icon-box myth-icon"><i class="fa-solid fa-bag-shopping"></i></div>
+            <h3>Myth</h3>
+            <p>Paper bags are always eco-friendly</p>
+            <div class="action-pill">Reveal Truth</div>
+          </div>
+        </div>
+        <div class="card-face card-back">
+          <div>
+            <div class="icon-box fact-icon"><i class="fa-solid fa-tree"></i></div>
+            <h3>Fact</h3>
+            <p>Reusable bags have the lowest impact.</p>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- CARD 4 -->
+    <div class="myth-card-wrapper">
+      <div class="myth-card" onclick="this.classList.toggle('flipped')">
+        <div class="card-face">
+          <div>
+            <div class="icon-box myth-icon"><i class="fa-solid fa-paw"></i></div>
+            <h3>Myth</h3>
+            <p>Feeding strays anything helps</p>
+            <div class="action-pill">Reveal Truth</div>
+          </div>
+        </div>
+        <div class="card-face card-back">
+          <div>
+            <div class="icon-box fact-icon"><i class="fa-solid fa-heart"></i></div>
+            <h3>Fact</h3>
+            <p>Unsafe food can harm animals. Feed responsibly.</p>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- CARD 5 -->
+    <div class="myth-card-wrapper">
+      <div class="myth-card" onclick="this.classList.toggle('flipped')">
+        <div class="card-face">
+          <div>
+            <div class="icon-box myth-icon"><i class="fa-solid fa-lightbulb"></i></div>
+            <h3>Myth</h3>
+            <p>Saving electricity doesn’t help</p>
+            <div class="action-pill">Reveal Truth</div>
+          </div>
+        </div>
+        <div class="card-face card-back">
+          <div>
+            <div class="icon-box fact-icon"><i class="fa-solid fa-plug"></i></div>
+            <h3>Fact</h3>
+            <p>Lower electricity use reduces pollution.</p>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- CARD 6 -->
+    <div class="myth-card-wrapper">
+      <div class="myth-card" onclick="this.classList.toggle('flipped')">
+        <div class="card-face">
+          <div>
+            <div class="icon-box myth-icon"><i class="fa-solid fa-tree"></i></div>
+            <h3>Myth</h3>
+            <p>Trees only provide oxygen</p>
+            <div class="action-pill">Reveal Truth</div>
+          </div>
+        </div>
+        <div class="card-face card-back">
+          <div>
+            <div class="icon-box fact-icon"><i class="fa-solid fa-cloud"></i></div>
+            <h3>Fact</h3>
+            <p>Trees regulate climate & water cycles.</p>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- CARD 7 -->
+    <div class="myth-card-wrapper">
+      <div class="myth-card" onclick="this.classList.toggle('flipped')">
+        <div class="card-face">
+          <div>
+            <div class="icon-box myth-icon"><i class="fa-solid fa-trash"></i></div>
+            <h3>Myth</h3>
+            <p>Waste segregation is useless</p>
+            <div class="action-pill">Reveal Truth</div>
+          </div>
+        </div>
+        <div class="card-face card-back">
+          <div>
+            <div class="icon-box fact-icon"><i class="fa-solid fa-recycle"></i></div>
+            <h3>Fact</h3>
+            <p>Segregation improves recycling & reduces landfill.</p>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- CARD 8 -->
+    <div class="myth-card-wrapper">
+      <div class="myth-card" onclick="this.classList.toggle('flipped')">
+        <div class="card-face">
+          <div>
+            <div class="icon-box myth-icon"><i class="fa-solid fa-fish"></i></div>
+            <h3>Myth</h3>
+            <p>Oceans clean themselves</p>
+            <div class="action-pill">Reveal Truth</div>
+          </div>
+        </div>
+        <div class="card-face card-back">
+          <div>
+            <div class="icon-box fact-icon"><i class="fa-solid fa-water"></i></div>
+            <h3>Fact</h3>
+            <p>Marine pollution seriously harms ocean life.</p>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- CARD 9 -->
+    <div class="myth-card-wrapper">
+      <div class="myth-card" onclick="this.classList.toggle('flipped')">
+        <div class="card-face">
+          <div>
+            <div class="icon-box myth-icon"><i class="fa-solid fa-globe"></i></div>
+            <h3>Myth</h3>
+            <p>Nature will fix everything</p>
+            <div class="action-pill">Reveal Truth</div>
+          </div>
+        </div>
+        <div class="card-face card-back">
+          <div>
+            <div class="icon-box fact-icon"><i class="fa-solid fa-hand-holding-heart"></i></div>
+            <h3>Fact</h3>
+            <p>Human responsibility is essential.</p>
+          </div>
+        </div>
+      </div>
+    </div>
+
+  </div>
+
+  <div class="back-wrapper">
+    <button class="back-btn" onclick="window.location.href='index.html'">← Back to Home</button>
+  </div>
+</section>
+
+<footer>
+  © 2026 EcoLife • Learn Green 💚
+</footer>
+
+</body>
+</html>


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #268 

## Rationale for this change

The Myth vs Fact section already existed on the index page, but it was limited
and not easily discoverable. Creating a dedicated page improves accessibility,
readability, and allows us to expand awareness content in a structured way.

## What changes are included in this PR?

- Created a dedicated **Myth vs Fact** page
- Extracted existing Myth vs Fact content from index
- Added **5 new environmental myths**, expanding total coverage
- Implemented interactive flip-card UI for better engagement
- Added a Back to Home button for easy navigation
- Ensured consistent UI with EcoLife theme

## Are these changes tested?

- [x] Tested locally in browser
- [x] Verified flip animations and responsiveness
- [x] Checked navigation back to home page

## Are there any user-facing changes?

Yes.
Users can now explore environmental myths and facts on a dedicated,
interactive page instead of a limited section on the homepage.

## Screenshots 
<img width="1900" height="909" alt="image" src="https://github.com/user-attachments/assets/34278c76-ea1d-42b4-a3ce-f6a684139f52" />
<img width="1902" height="900" alt="image" src="https://github.com/user-attachments/assets/311efcab-5b75-4805-a874-b9d993f8161d" />

