### PR TITLE
Remove Myth Section from Home and Add Myth vs Fact Navigation Link

### DIFF
--- a/frontend/src/index.html
+++ b/frontend/src/index.html
@@ -61,8 +61,9 @@
         <li><a href="#home" class="nav-link active">Home</a></li>
         <li><a href="#about" class="nav-link">About</a></li>
         <li><a href="#animal" class="nav-link">Animals</a></li>
-        <li><a href="pages/endangered-animals.html" class="nav-link">🐾 Endangered Animals</a></li>
-        <li><a href="pages/sos.html" class="nav-link">🆘 SOS Emergency</a></li>
+        <li><a href="../src/pages/myth-vs-fact.html" class="nav-link">MythVsFact</a></li>
+        <li><a href="pages/endangered-animals.html" class="nav-link">Endangered Animals</a></li>
+        <li><a href="pages/sos.html" class="nav-link">SOS Emergency</a></li>
         <li><a href="#environment" class="nav-link">Environment</a></li>
         <li><a href="./pages/kids-zone.html" class="nav-link">Kids Zone</a></li>
         <li><a href="./pages/report.html" class="nav-link">Report</a></li>
@@ -1154,111 +1155,7 @@
 
   </section>
 
-  <!-- myth fact -->
-
-  <section class="myth-fact-section">
-    <div class="section-container" data-aos="fade-up" data-aos-delay="300">
-      <div class="section-header">
-        <span class="section-tag">🌱 Knowledge Roots</span>
-        <h2 class="section-title">Nature vs. Fiction</h2>
-        <p class="section-subtitle">Tap a card to reveal the green truth.</p>
-      </div>
-
-      <div class="myth-fact-grid">
-
-        <div class="myth-card-wrapper">
-          <div class="myth-card" onclick="this.classList.toggle('flipped')">
-            <div class="card-face card-front">
-              <div class="card-shine"></div>
-              <div class="card-content">
-                <div class="icon-box myth-icon"><i class="fa-solid fa-recycle"></i></div>
-                <h3>Myth</h3>
-                <p>"Plastic is fully recyclable"</p>
-                <div class="action-pill">Reveal Truth</div>
-              </div>
-            </div>
-            <div class="card-face card-back">
-              <div class="card-shine"></div>
-              <div class="card-content">
-                <div class="icon-box fact-icon"><i class="fa-solid fa-earth-americas"></i></div>
-                <h3>Fact</h3>
-                <p>Only ~9% of plastic is recycled. Reduce & Reuse is the real solution!</p>
-              </div>
-            </div>
-          </div>
-        </div>
-
-        <div class="myth-card-wrapper">
-          <div class="myth-card" onclick="this.classList.toggle('flipped')">
-            <div class="card-face card-front">
-              <div class="card-shine"></div>
-              <div class="card-content">
-                <div class="icon-box myth-icon"><i class="fa-solid fa-user-xmark"></i></div>
-                <h3>Myth</h3>
-                <p>"My actions are too small"</p>
-                <div class="action-pill">Reveal Truth</div>
-              </div>
-            </div>
-            <div class="card-face card-back">
-              <div class="card-shine"></div>
-              <div class="card-content">
-                <div class="icon-box fact-icon"><i class="fa-solid fa-users-rays"></i></div>
-                <h3>Fact</h3>
-                <p>Collective action drives policy. 1 million people making small changes creates huge impact.
-                </p>
-              </div>
-            </div>
-          </div>
-        </div>
-
-        <div class="myth-card-wrapper">
-          <div class="myth-card" onclick="this.classList.toggle('flipped')">
-            <div class="card-face card-front">
-              <div class="card-shine"></div>
-              <div class="card-content">
-                <div class="icon-box myth-icon"><i class="fa-solid fa-bag-shopping"></i></div>
-                <h3>Myth</h3>
-                <p>"Paper bags are eco-friendly"</p>
-                <div class="action-pill">Reveal Truth</div>
-              </div>
-            </div>
-            <div class="card-face card-back">
-              <div class="card-shine"></div>
-              <div class="card-content">
-                <div class="icon-box fact-icon"><i class="fa-solid fa-tree"></i></div>
-                <h3>Fact</h3>
-                <p>Paper production uses huge amounts of water/energy. Reusable bags are best!</p>
-              </div>
-            </div>
-          </div>
-        </div>
-
-        <div class="myth-card-wrapper">
-          <div class="myth-card" onclick="this.classList.toggle('flipped')">
-            <div class="card-face card-front">
-              <div class="card-shine"></div>
-              <div class="card-content">
-                <div class="icon-box myth-icon"><i class="fa-solid fa-temperature-arrow-up"></i></div>
-                <h3>Myth</h3>
-                <p>"Climate change is natural"</p>
-                <div class="action-pill">Reveal Truth</div>
-              </div>
-            </div>
-            <div class="card-face card-back">
-              <div class="card-shine"></div>
-              <div class="card-content">
-                <div class="icon-box fact-icon"><i class="fa-solid fa-smog"></i></div>
-                <h3>Fact</h3>
-                <p>Current warming is 10x faster than natural cycles, driven by human emissions.</p>
-              </div>
-            </div>
-          </div>
-        </div>
-
-      </div>
-    </div>
-  </section>
-
+  
   <section class="glossary-section">
     <div class="section-container">
       <div class="section-header">


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #346 

## Rationale for this change

The Myth section was previously displayed on the Home page, which caused duplication after introducing a dedicated Myth vs Fact page.  
Additionally, there was no direct navigation option for users to access the Myth vs Fact content.

To improve content organization and user experience, the Myth section has been moved exclusively to its own page and linked properly through the navigation bar.

## What changes are included in this PR?

- Removed the Myth vs Fact section from the Home (index) page
- Added a new "Myth vs Fact" link in the navigation bar
- Ensured Myth-related content exists only on the dedicated Myth vs Fact page
- Improved navigation clarity and avoided content duplication

## Are these changes tested?

Yes.
- Verified that the Myth section no longer appears on the Home page
- Confirmed that the "Myth vs Fact" navigation link redirects correctly to the dedicated page
- Checked that the layout and navigation work as expected across pages

## Are there any user-facing changes?

Yes.
- Users can now access Myth vs Fact content directly via the navigation bar
- The Home page is cleaner and more focused without duplicate content

## Screenshots
<img width="1541" height="66" alt="image" src="https://github.com/user-attachments/assets/da8bb977-68b6-4480-b649-fc9cb013e2d9" />
