### PR TITLE
Add 'Play Now' button to kids zone game card

### DIFF
--- a/frontend/src/pages/kids-zone.html
+++ b/frontend/src/pages/kids-zone.html
@@ -1064,6 +1064,11 @@
           <span>Age 6+</span>
         </div>
         <a href="./eco-builder.html" class="play-btn">
+          <i class="fas fa-play-circle"></i>
+          Play Now
+        </a>
+      </div>
+    </div>
     <!-- Game 9 - eco builder -->
     <div class="game-card animate-card" style="animation-delay: 1.0s">
       <span class="card-badge badge-new">New</span>


### PR DESCRIPTION
### 🛠️ Problem
The previous merge of PR #521 caused a layout regression in `kids-zone.html`, breaking the dashboard grid.

### ✅ Solution
- Restored the structural integrity of the Kids Zone dashboard.
- Fixed the alignment for all game cards, including the new **Eco-Builder**.
- Verified all navigation links are functional.
- This PR addresses the feedback from @Nikhilrsingh regarding the broken dashboard.

Addresses feedback on PR #521. 