### PR TITLE
fix: resolve broken navigation, redundant theme toggles #Issue 580

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,10 +4,9 @@
 
 
 <head>
-  <link rel="icon" type="image/png" href="/envirnoment-logo.png">
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <link rel="icon" type="image/png" href="assets/FAVICON.png">
+  <link rel="icon" type="image/png" href="assets/images/others/envirnoment-logo.png">
   <title>EcoLife | Protect Our Planet & Animals</title>
   <meta name="description"
     content="Join EcoLife to protect animals, save the environment, and create a greener future for all." />

--- a/frontend/pages/join-garden-drive.html
+++ b/frontend/pages/join-garden-drive.html
@@ -28,12 +28,6 @@
 </head>
 
 <body>
-    <!-- Theme Toggle Button -->
-    <button class="theme-toggle" id="themeToggle" aria-label="Toggle theme">
-        <i class="fas fa-moon"></i>
-        <i class="fas fa-sun"></i>
-    </button>
-
     <header class="page-top">
         <nav>
       <div>

--- a/frontend/pages/myth-vs-fact.html
+++ b/frontend/pages/myth-vs-fact.html
@@ -353,7 +353,7 @@ footer{
   </div>
 
   <div class="back-wrapper">
-    <button class="back-btn" onclick="window.location.href='index.html'">← Back to Home</button>
+    <button class="back-btn" onclick="window.location.href='../index.html'">← Back to Home</button>
   </div>
 </section>
 

--- a/frontend/pages/plant-care.html
+++ b/frontend/pages/plant-care.html
@@ -3,9 +3,8 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <link rel="icon" type="image/png" href="../assets/images/others/FAVICON.png"> 
+    <link rel="icon" type="image/png" href="../assets/images/others/envirnoment-logo.png"> 
     <title>Plant Care | EcoLife</title>
-    <link rel="icon" type="image/png" href="/envirnoment-logo.png">
     <meta name="description" content="Expert gardening tips and plant care guide." />
 
     <link rel="stylesheet" href="../css/style.css" />

--- a/frontend/pages/sitemap.html
+++ b/frontend/pages/sitemap.html
@@ -600,11 +600,6 @@
 
 <body>
   <div id="navbar-container"></div>
-  <!-- Theme Toggle -->
-  <button class="theme-toggle" id="themeToggle" aria-label="Toggle theme">
-    <i class="fas fa-moon"></i>
-    <i class="fas fa-sun"></i>
-  </button>
 
   <!-- HERO -->
   <section class="hero">

--- a/frontend/pages/visual-mueseum.html
+++ b/frontend/pages/visual-mueseum.html
@@ -22,10 +22,6 @@
 </head>
 
 <body>
-    
-    <div class="theme-toggle" id="themeToggle">
-        <i class="fas fa-moon"></i>
-    </div>
     <!-- Loading Animation -->
     <div class="loading-overlay" id="loadingOverlay">
         <div class="museum-loader">


### PR DESCRIPTION
## Description 
This PR resolves several minor bugs and UI inconsistencies found throughout the repository after syncing with the upstream main branch.

Related Issue : #580 

### Problems Identified:
1. **Broken Home Navigation**: The "Back to Home" button in `myth-vs-fact.html` was incorrectly linked to `index.html` (relative to the current file, this should be `../index.html`).
2. **Redundant Theme Toggles**: Several pages (`join-garden-drive.html`, `sitemap.html`, `visual-mueseum.html`) had hardcoded theme toggle buttons that conflicted with the centralized theme toggle now included in the `navbar.html` component.
3. **Invalid/Duplicate Favicon Paths**: 
    - `index.html` had duplicate favicon links, one of which was an absolute path `/envirnoment-logo.png` (missing a directory).
    - `plant-care.html` was missing the correct relative path for the favicon.
4. **Incorrect Asset References**: Some icons were pointing to `assets/FAVICON.png` instead of the correct location in `assets/images/...`.

## Changes Made:
- [x] Updated `myth-vs-fact.html` back button link to `../index.html`.
- [x] Removed redundant floating theme toggle buttons from `join-garden-drive.html`, `sitemap.html`, and `visual-mueseum.html`.
- [x] Sanitized favicon links in `index.html` and `plant-care.html` to point to `assets/images/others/envirnoment-logo.png`.
- [x] Standardized navbar injection in pages to avoid UI conflicts.

## Impact:
- Improved navigation reliability.
- cleaner UI with no duplicate controls.
- Consistent branding with working favicons across all pages.