### PR TITLE
Fix: Resolve duplicate head tags in sitemap.html - Issue #601

### DIFF
--- a/frontend/pages/sitemap.html
+++ b/frontend/pages/sitemap.html
@@ -12,10 +12,11 @@
   
   <!-- AOS Animation -->
   <link href="https://unpkg.com/aos@2.3.4/dist/aos.css" rel="stylesheet">
+  
+  <!-- Page Styles -->
   <link rel="stylesheet" href="../css/pages/sitemap.css">
-
-</head>
-
+  
+  <!-- Component Styles -->
   <link rel="stylesheet" href="../css/components/footer.css" />
   <link rel="stylesheet" href="../css/components/navbar.css" />
 </head>


### PR DESCRIPTION
This PR resolves Issue #601 by fixing the HTML structure of the sitemap page. The external CSS file (
sitemap.css
) was already created, but there was a duplicate </head> tag causing improper HTML structure.

🔧 Changes Made
✅ Fixed duplicate </head> tags in 
sitemap.html
✅ Properly organized CSS link tags in the head section
✅ Added comments to organize Page Styles and Component Styles sections
✅ External CSS file 
frontend/css/pages/sitemap.css
 already exists with all styles (579 lines)
✅ No inline <style> blocks remain in 
sitemap.html
✅ Acceptance Criteria Met
 External file 
frontend/css/pages/sitemap.css
 exists
 
sitemap.html
 links to the external CSS file
 No inline <style> block remains in 
sitemap.html
 Page structure is clean and follows best practices
 The page looks and behaves exactly the same as before
🧪 Testing
Verified HTML structure is valid
Confirmed all CSS links are properly included
No visual or functional changes to the page
📝 Technical Details
Before:

Duplicate </head> tags on lines 17 and 21
CSS links split across the duplicate head sections
After:

Single, properly structured </head> tag
All CSS links organized with clear comments
Clean, maintainable HTML structure
Closes #601


