### PR TITLE
Fix: Display quiz score in clear “X out of Y” format on result screen

### DIFF
--- a/frontend/js/pages/quizzes/plant-care-quiz.js
+++ b/frontend/js/pages/quizzes/plant-care-quiz.js
@@ -67,12 +67,15 @@ function nextQuestion(){
   index++;
   index<quiz.length ? loadQuestion() : showResult();
 }
-
 function showResult(){
   clearInterval(timer);
   quizScreen.style.display="none";
   resultScreen.style.display="block";
-  score.textContent=`${score} / ${quiz.length}`;
+
+  // ADD HERE (replace old score line)
+  document.getElementById("score").textContent =
+    `You scored ${score} out of ${quiz.length}`;
+
   remark.textContent =
     score>=6 ? "🌟 Plant Care Pro!" :
     score>=4 ? "👍 Good Job!" :


### PR DESCRIPTION
## 🔖 PR Title
Fix: Display quiz score in clear “X out of Y” format on result screen

---

## Which issue does this PR close?

- Closes #616 

---

## Rationale for this change

The Plant Care Quiz result screen was not clearly displaying the total marks.  
Users could only see a partial score, which made it difficult to understand overall performance.  
This change improves clarity by showing the score in a readable format without altering existing logic or UI.

---

## What changes are included in this PR?

- Updated the quiz result display to show score in the format:
  **“You scored X out of Y”**
- Included the total number of questions attempted
- No changes to HTML structure, CSS, or quiz flow

---

## Are these changes tested?

Yes.  
The quiz was tested by completing multiple attempts with different answer selections to verify:
- Correct score calculation
- Correct total question count display
- No impact on timer or navigation

---

## Are there any user-facing changes?

Yes.  
Users can now clearly see their final score along with the total marks on the result screen.

---

## Screenshots 
Before
<img width="1822" height="868" alt="image" src="https://github.com/user-attachments/assets/32317a37-ab94-47d7-821f-dc5c6a477de6" />

After
<img width="1060" height="601" alt="image" src="https://github.com/user-attachments/assets/5151b85a-c82b-41b9-b530-0c79205c590a" />

