### PR TITLE
Fix: Add emoji reactions (thumbs up/down) to posts - Issue #703

### DIFF
--- a/EMOJI_REACTIONS_IMPLEMENTATION.md
+++ b/EMOJI_REACTIONS_IMPLEMENTATION.md
@@ -1,0 +1,71 @@
+# Emoji Reactions Implementation - Issue #703
+
+## Summary
+Added thumbs up/down emoji reactions to posts in the community page.
+
+## Changes Made
+
+### 1. Updated `frontend/js/pages/community/post.js`
+- Added emoji reactions HTML structure to post cards (lines 57-67)
+- Implemented click event listeners for emoji reactions with count tracking (lines 136-156)
+- Added emoji reactions to new post creation template (lines 224-234)
+- Updated `attachPostListeners()` function to include emoji reaction handlers for dynamically created posts (lines 304-324)
+
+### 2. Updated `frontend/css/pages/community.css`
+- Added comprehensive styling for emoji reactions (lines 403-465)
+- Implemented hover effects with scale transformation
+- Added active state styling with shadow effects
+- Created bounce animation for emoji icons when clicked
+- Styled emoji counts with proper typography
+
+## Features Implemented
+
+### Quick Feedback Mechanism
+✅ **Thumbs Up (👍)**: Users can express positive feedback
+✅ **Thumbs Down (👎)**: Users can express negative feedback
+
+### Interactive Behavior
+- **Click to React**: Click an emoji to add your reaction
+- **Toggle Support**: Click again to remove your reaction
+- **Live Count Updates**: Reaction counts update in real-time
+- **Visual Feedback**: 
+  - Hover effects with scale animation
+  - Active state with green background
+  - Bounce animation on click
+  - Smooth transitions
+
+### Styling Features
+- Rounded pill-shaped buttons
+- Color-coded active states (green theme)
+- Responsive hover effects
+- Smooth animations and transitions
+- Dark mode compatible
+
+## Testing Instructions
+
+1. Open `frontend/pages/community/post.html` in a browser
+2. Scroll through the posts
+3. Click on the 👍 or 👎 emojis on any post
+4. Verify that:
+   - The count increases when clicked
+   - The emoji button changes to active state (green background)
+   - Clicking again decreases the count
+   - The active state is removed when toggled off
+   - Hover effects work smoothly
+   - The bounce animation plays on click
+
+## Files Modified
+- `frontend/js/pages/community/post.js` - Added emoji reaction functionality
+- `frontend/css/pages/community.css` - Added emoji reaction styles
+
+## Why This Change?
+This feature provides users with a quick and intuitive way to react to posts without writing comments. It enhances user engagement and provides immediate feedback to content creators.
+
+## Screenshots
+Please test the feature in your browser at:
+`file:///C:/Users/91720/open%20source/Environment_Animal_Safety_Hub/frontend/pages/community/post.html`
+
+---
+**Issue**: #703
+**Status**: ✅ Completed
+**Date**: 2026-01-16

--- a/frontend/css/pages/community.css
+++ b/frontend/css/pages/community.css
@@ -400,6 +400,71 @@ body.page.dashboard {
   color: #2ecc71;
 }
 
+/* Emoji Reactions */
+.emoji-reactions {
+  display: flex;
+  gap: 15px;
+  padding: 10px 15px;
+  align-items: center;
+}
+
+.emoji-reaction {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 16px;
+  background: var(--background);
+  border: 2px solid transparent;
+  border-radius: 20px;
+  cursor: pointer;
+  transition: all 0.3s ease;
+  user-select: none;
+}
+
+.emoji-reaction:hover {
+  background: var(--primary-color);
+  border-color: var(--primary-color);
+  transform: scale(1.05);
+}
+
+.emoji-reaction.active {
+  background: var(--primary-color);
+  border-color: var(--primary-hover);
+  box-shadow: 0 4px 12px rgba(30, 127, 92, 0.3);
+}
+
+.emoji-icon {
+  font-size: 20px;
+  transition: transform 0.3s ease;
+}
+
+.emoji-reaction:hover .emoji-icon {
+  transform: scale(1.2);
+}
+
+.emoji-reaction.active .emoji-icon {
+  animation: bounce 0.5s ease;
+}
+
+@keyframes bounce {
+  0%, 100% { transform: scale(1); }
+  50% { transform: scale(1.3); }
+}
+
+.emoji-count {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--text-primary);
+  min-width: 20px;
+  text-align: center;
+  transition: color 0.3s ease;
+}
+
+.emoji-reaction:hover .emoji-count,
+.emoji-reaction.active .emoji-count {
+  color: #fff;
+}
+
 /* Comment Panel */
 .comment-panel {
   border-top: 1px solid #ddd;

--- a/frontend/js/pages/community/post.js
+++ b/frontend/js/pages/community/post.js
@@ -54,6 +54,17 @@ function loadPost(count = 3) {
         <span class="comments-count">${post.comments}</span> comments
       </div>
 
+      <div class="emoji-reactions">
+        <div class="emoji-reaction" data-emoji="thumbsup">
+          <span class="emoji-icon">👍</span>
+          <span class="emoji-count">0</span>
+        </div>
+        <div class="emoji-reaction" data-emoji="thumbsdown">
+          <span class="emoji-icon">👎</span>
+          <span class="emoji-count">0</span>
+        </div>
+      </div>
+
       <div class="comment-panel column" style="display:none;">
         <div class="comments-list column"></div>
         <input class="input comment-input" type="text" placeholder="Write a comment...">
@@ -80,7 +91,7 @@ function loadPost(count = 3) {
     // Like
     likeBtn.addEventListener("click", () => {
       likeBtn.classList.toggle("active");
-      likeBtn.classList.contains("active") 
+      likeBtn.classList.contains("active")
         ? likeBtn.classList.replace("fa-regular", "fa-solid")
         : likeBtn.classList.replace("fa-solid", "fa-regular");
 
@@ -106,7 +117,7 @@ function loadPost(count = 3) {
     // Add comment
     addCommentBtn.addEventListener("click", () => {
       const text = commentInput.value.trim();
-      if(text !== "") {
+      if (text !== "") {
         const commentEl = document.createElement("div");
         commentEl.classList.add("comment-item");
         commentEl.textContent = text;
@@ -120,6 +131,26 @@ function loadPost(count = 3) {
         commentInput.value = "";
         updateNoCommentText();
       }
+    });
+
+    // Emoji Reactions
+    const emojiReactions = postCard.querySelectorAll(".emoji-reaction");
+    emojiReactions.forEach(reaction => {
+      reaction.addEventListener("click", () => {
+        const emojiCount = reaction.querySelector(".emoji-count");
+        let count = parseInt(emojiCount.textContent);
+
+        // Toggle reaction - if already clicked, decrease count, else increase
+        if (reaction.classList.contains("active")) {
+          count = Math.max(0, count - 1);
+          reaction.classList.remove("active");
+        } else {
+          count += 1;
+          reaction.classList.add("active");
+        }
+
+        emojiCount.textContent = count;
+      });
     });
 
     function updateNoCommentText() {
@@ -156,7 +187,7 @@ closeModal.addEventListener("click", () => {
 });
 
 window.addEventListener("click", (e) => {
-  if(e.target === modal){
+  if (e.target === modal) {
     modal.style.display = "none";
   }
 });
@@ -166,7 +197,7 @@ submitPostBtn.addEventListener("click", () => {
   const desc = postDescInput.value.trim();
   const imageFile = postImageInput.files[0];
 
-  if(!desc && !imageFile) return alert("Add description or image");
+  if (!desc && !imageFile) return alert("Add description or image");
 
   const postCard = document.createElement("div");
   postCard.className = "post-card";
@@ -190,6 +221,16 @@ submitPostBtn.addEventListener("click", () => {
       <span class="likes-count">0</span> likes • 
       <span class="comments-count">0</span> comments
     </div>
+    <div class="emoji-reactions">
+      <div class="emoji-reaction" data-emoji="thumbsup">
+        <span class="emoji-icon">👍</span>
+        <span class="emoji-count">0</span>
+      </div>
+      <div class="emoji-reaction" data-emoji="thumbsdown">
+        <span class="emoji-icon">👎</span>
+        <span class="emoji-count">0</span>
+      </div>
+    </div>
     <div class="comment-panel column" style="display:none;">
       <div class="comments-list column"></div>
       <input class="input comment-input" type="text" placeholder="Write a comment...">
@@ -210,7 +251,7 @@ submitPostBtn.addEventListener("click", () => {
 });
 
 // Function to attach likes/comments/save listeners
-function attachPostListeners(postCard){
+function attachPostListeners(postCard) {
   const likeBtn = postCard.querySelector(".like-btn");
   const saveBtn = postCard.querySelector(".save-btn");
   const commentBtn = postCard.querySelector(".comment-btn");
@@ -246,7 +287,7 @@ function attachPostListeners(postCard){
   // Add comment
   addCommentBtn.addEventListener("click", () => {
     const text = commentInput.value.trim();
-    if(text !== ""){
+    if (text !== "") {
       const commentEl = document.createElement("div");
       commentEl.classList.add("comment-item");
       commentEl.textContent = text;
@@ -259,5 +300,25 @@ function attachPostListeners(postCard){
       commentInput.value = "";
       noComment.style.display = "none";
     }
+  });
+
+  // Emoji Reactions
+  const emojiReactions = postCard.querySelectorAll(".emoji-reaction");
+  emojiReactions.forEach(reaction => {
+    reaction.addEventListener("click", () => {
+      const emojiCount = reaction.querySelector(".emoji-count");
+      let count = parseInt(emojiCount.textContent);
+
+      // Toggle reaction - if already clicked, decrease count, else increase
+      if (reaction.classList.contains("active")) {
+        count = Math.max(0, count - 1);
+        reaction.classList.remove("active");
+      } else {
+        count += 1;
+        reaction.classList.add("active");
+      }
+
+      emojiCount.textContent = count;
+    });
   });
 }


### PR DESCRIPTION
# Add Emoji Reactions to Posts - Issue #703

## Summary
Adds thumbs up (👍) and thumbs down (👎) emoji reactions to posts in the community page.

## Changes Made
✅ Added emoji reactions UI in `pages/community/`  
✅ Implemented JavaScript for click count tracking  
✅ Added CSS styling with animations and hover effects  

## Why This Change?
Provides users with a quick feedback mechanism to react to posts without writing comments. Enhances user engagement and interaction.

## Features
- Click emoji to add reaction (count increases)
- Click again to remove reaction (count decreases)
- Smooth hover effects and animations
- Dark mode compatible
- Works on both existing and new posts

## Testing
✅ Click emojis; counts update correctly  
✅ Toggle functionality works (click to add/remove)  
✅ Animations and hover effects work smoothly  
✅ Works in both light and dark mode  
✅ New posts also have emoji reactions  

## Files Modified
- `frontend/js/pages/community/post.js` - Added emoji reaction functionality
- `frontend/css/pages/community.css` - Added emoji reaction styles

## Screenshots

![Uploading Screenshot 2026-01-16 113725.png…]()

---
**Closes #703**
