### PR TITLE
[Refactor] Externalize Inline Script for Join Garden Drive Page #884

### DIFF
--- a/frontend/pages/join-garden-drive.html
+++ b/frontend/pages/join-garden-drive.html
@@ -157,30 +157,6 @@
 
     <!-- Footer placeholder -->
   <div id="footer-placeholder"></div>
-<script>
-        // Theme Toggle Functionality
-        const themeToggle = document.getElementById('themeToggle');
-        const prefersDarkScheme = window.matchMedia('(prefers-color-scheme: dark)');
-        
-        // Check for saved theme or preferred scheme
-        const currentTheme = localStorage.getItem('theme');
-        if (currentTheme === 'dark' || (!currentTheme && prefersDarkScheme.matches)) {
-            document.body.classList.add('dark-theme');
-            themeToggle.classList.add('dark');
-        }
-        
-        themeToggle.addEventListener('click', () => {
-            document.body.classList.toggle('dark-theme');
-            themeToggle.classList.toggle('dark');
-            
-            // Save preference
-            if (document.body.classList.contains('dark-theme')) {
-                localStorage.setItem('theme', 'dark');
-            } else {
-                localStorage.setItem('theme', 'light');
-            }
-        });
-    </script>
 
     <script>
         (function(){if(!window.chatbase||window.chatbase("getState")!=="initialized"){window.chatbase=(...arguments)=>{if(!window.chatbase.q){window.chatbase.q=[]}window.chatbase.q.push(arguments)};window.chatbase=new Proxy(window.chatbase,{get(target,prop){if(prop==="q"){return target.q}return(...args)=>target(prop,...args)}})}const onLoad=function(){const script=document.createElement("script");script.src="https://www.chatbase.co/embed.min.js";script.id="ws110ZzXAkEnbVsIy9g8d";script.domain="www.chatbase.co";document.body.appendChild(script)};if(document.readyState==="complete"){onLoad()}else{window.addEventListener("load",onLoad)}})();


### PR DESCRIPTION
## 📋 Summary
Fixes #884 

Removed redundant inline theme toggle script from [join-garden-drive.html](cci:7://file:///c:/Users/91720/open%20source/Environment_Animal_Safety_Hub/frontend/pages/join-garden-drive.html:0:0-0:0) that was duplicating functionality already provided by the external [theme-toggle.js](cci:7://file:///c:/Users/91720/open%20source/Environment_Animal_Safety_Hub/frontend/js/global/theme-toggle.js:0:0-0:0) module.

## ⚙️ Changes Made
- Removed inline `<script>` block (lines 160-183) containing theme toggle logic
- Page now relies entirely on `../js/global/theme-toggle.js` for theme switching

## 🐛 Bug Fixed
- Eliminated potential race condition where inline script tried to access `themeToggle` element before navbar was loaded
- Prevents console errors regarding `themeToggle` being null

## ✅ Acceptance Criteria Met
- [x] No inline theme toggle script remains in join-garden-drive.html
- [x] Theme toggle button in navbar continues to work correctly (handled by theme-toggle.js)
- [x] No console errors regarding themeToggle being null

## 🧪 Testing
The theme toggle functionality is now handled by:
1. `../js/global/theme-toggle.js` - Comprehensive theme system
2. `../js/components/navbar-loader.js` - Loads navbar with toggle button

## 📊 Impact
- **24 lines removed** - Cleaner, more maintainable code
- **0 functionality lost** - All features preserved through external script
- **Bug prevention** - Eliminates race condition issues