### PR TITLE
[Refactor] Externalize Inline Styles for Terms & Conditions Page

### DIFF
--- a/frontend/css/pages/terms-and-conditions.css
+++ b/frontend/css/pages/terms-and-conditions.css
@@ -498,6 +498,30 @@ footer {
   }
 }
 
+/* ===== PRINT BUTTON ===== */
+.print-btn {
+  position: fixed;
+  bottom: 90px;
+  right: 20px;
+  width: 50px;
+  height: 50px;
+  border-radius: 50%;
+  background: var(--primary);
+  color: white;
+  border: none;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 99;
+  box-shadow: var(--shadow);
+  transition: var(--transition);
+}
+
+.print-btn:hover {
+  transform: scale(1.1);
+}
+
 /* ===== SCROLLBAR ===== */
 ::-webkit-scrollbar {
   width: 10px;

--- a/frontend/pages/terms-and-conditions.html
+++ b/frontend/pages/terms-and-conditions.html
@@ -396,34 +396,9 @@
 
         // ===== PRINT FUNCTIONALITY =====
         const printBtn = document.createElement('button');
+        printBtn.className = 'print-btn';
         printBtn.innerHTML = '<i class="fas fa-print"></i>';
         printBtn.title = 'Print Terms';
-        printBtn.style.cssText = `
-            position: fixed;
-            bottom: 90px;
-            right: 20px;
-            width: 50px;
-            height: 50px;
-            border-radius: 50%;
-            background: var(--primary);
-            color: white;
-            border: none;
-            cursor: pointer;
-            display: flex;
-            align-items: center;
-            justify-content: center;
-            z-index: 99;
-            box-shadow: var(--shadow);
-            transition: var(--transition);
-        `;
-
-        printBtn.addEventListener('mouseenter', () => {
-            printBtn.style.transform = 'scale(1.1)';
-        });
-
-        printBtn.addEventListener('mouseleave', () => {
-            printBtn.style.transform = 'scale(1)';
-        });
 
         printBtn.addEventListener('click', () => {
             window.print();


### PR DESCRIPTION
## 📋 Summary
This PR externalizes the inline CSS styles from the Terms & Conditions page, moving them to the external stylesheet for better maintainability and consistency with the project structure.

## ⚙️ Changes Made
- Extracted print button inline CSS styles from JavaScript
- Added `.print-btn` class to `frontend/css/pages/terms-and-conditions.css`
- Updated JavaScript to use CSS class instead of inline `style.cssText`
- Replaced mouseenter/mouseleave event listeners with CSS `:hover` pseudo-class

## 🔍 Files Modified
- `frontend/css/pages/terms-and-conditions.css` - Added print button styles
- `frontend/pages/terms-and-conditions.html` - Removed inline styles from JavaScript

## ✅ Acceptance Criteria
- [x] All inline styles removed from JavaScript
- [x] Styles moved to external CSS file
- [x] Visual appearance remains unchanged
- [x] Functionality preserved
- [x] Code is cleaner and more maintainable

## 🧪 Testing
- Page loads correctly with all styles applied
- Print button displays and functions as expected
- Hover effects work properly
- Dark mode compatibility maintained

## 📝 Related Issue
Fixes #883

