### PR TITLE
Fix footer policy links causing 404 on GitHub Pages (#1589)

### DIFF
--- a/frontend/components/footer.html
+++ b/frontend/components/footer.html
@@ -115,11 +115,11 @@
           </span>
         </p>
 
-        <div class="footer-legal-links">
-          <a href="/frontend/pages/privacy-policy.html">Privacy Policy</a>
-          <a href="/frontend/pages/terms-and-conditions.html">Terms & Conditions</a>
-          <a href="/frontend/pages/cookie-policy.html">Cookie Policy</a>
-        </div>
+       <div class="footer-legal-links">
+  <a href="pages/privacy-policy.html">Privacy Policy</a>
+  <a href="pages/terms-and-conditions.html">Terms & Conditions</a>
+  <a href="pages/cookie-policy.html">Cookie Policy</a>
+</div>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## 🐞 Issue
Fixes #1589

## ✅ What was fixed
- Corrected footer links for:
  - Privacy Policy
  - Terms & Conditions
  - Cookie Policy
- Updated links to use relative paths so they work correctly on GitHub Pages.

## 🧪 Testing
- Verified all footer policy links open correctly on the live site.
- No 404 errors observed.

## 🔍 Scope
- Frontend-only changes
- No backend files modified

## 🎯 Program
This contribution is made under **ECWoC’26**.

## Screenshots
**Before**
<img width="1919" height="970" alt="Screenshot 2026-01-30 163141" src="https://github.com/user-attachments/assets/096d5dca-ca00-4337-ab5d-81c38062d3aa" />
 
**After**
<img width="1919" height="971" alt="Screenshot 2026-01-30 163152" src="https://github.com/user-attachments/assets/9fd91da8-6983-48b5-9df4-87afa2e5f0f2" />

<img width="1919" height="965" alt="Screenshot 2026-01-30 163205" src="https://github.com/user-attachments/assets/36ed975b-c0ec-4199-bfb6-c0ff180c6637" />

<img width="1919" height="974" alt="Screenshot 2026-01-30 163213" src="https://github.com/user-attachments/assets/ca169b7a-766a-419d-afc2-4aaac5b9ed8e" />

