### PR TITLE
Fix admin social media links in footer (Issue #1642)

### DIFF
--- a/frontend/components/footer.html
+++ b/frontend/components/footer.html
@@ -14,10 +14,26 @@
           sustainable living.
         </p>
         <div class="footer-social">
-          <a href="#" class="social" aria-label="Facebook"><i class="fa-brands fa-facebook-f"></i></a>
-          <a href="#" class="social" aria-label="Twitter"><i class="fa-brands fa-twitter"></i></a>
-          <a href="#" class="social" aria-label="Instagram"><i class="fa-brands fa-instagram"></i></a>
-          <a href="#" class="social" aria-label="LinkedIn"><i class="fa-brands fa-linkedin-in"></i></a>
+          <a href="https://www.facebook.com" target="_blank" rel="noopener noreferrer"
+             class="social" aria-label="Facebook">
+            <i class="fa-brands fa-facebook-f"></i>
+          </a>
+        
+          <a href="https://twitter.com" target="_blank" rel="noopener noreferrer"
+             class="social" aria-label="Twitter">
+            <i class="fa-brands fa-twitter"></i>
+          </a>
+        
+          <a href="https://www.instagram.com" target="_blank" rel="noopener noreferrer"
+             class="social" aria-label="Instagram">
+            <i class="fa-brands fa-instagram"></i>
+          </a>
+        
+          <a href="https://www.linkedin.com/in/jagrati-312301344/"
+             target="_blank" rel="noopener noreferrer"
+             class="social" aria-label="LinkedIn">
+            <i class="fa-brands fa-linkedin-in"></i>
+          </a>
         </div>
       </div>
 


### PR DESCRIPTION
### This PR resolves Issue #1642 by updating the footer social media links.

### Changes made:
- LinkedIn icon now points to the official admin profile
- Other social icons redirect to their respective official platforms
- Removed placeholder (#) links for better UX and clarity
- External links open safely in a new tab

Kindly review and merge.

### Screen Recording
https://github.com/user-attachments/assets/eb690770-b2ca-48c8-ba9b-4e6102af9e84

### Closes #1642 