### PR TITLE
fix: resolve Home ↔ About navbar redirection inconsistency (#2061)

### DIFF
--- a/frontend/js/components/component-loader.js
+++ b/frontend/js/components/component-loader.js
@@ -155,11 +155,18 @@
 
             links.forEach(link => {
                 const href = link.getAttribute('href');
-                if (href && !href.startsWith('http') && !href.startsWith('#') && !href.startsWith('mailto:')) {
+                        
+                if (
+                    href &&
+                    !href.startsWith('http') &&
+                    !href.startsWith('#') &&
+                    !href.startsWith('mailto:') &&
+                    !href.startsWith('/')
+                ) {
                     link.setAttribute('href', prefix + href);
                 }
             });
-
+            
             images.forEach(img => {
                 const src = img.getAttribute('src');
                 if (src && !src.startsWith('http')) {


### PR DESCRIPTION
## 🐞 Fix: Navbar Home ↔ About Redirection Issue (#2061)

### 📌 Issue
There was an inconsistency in navbar navigation:
- Home → About worked correctly.
- About → Home did not redirect properly.

This was caused by incorrect relative path handling when the navbar was dynamically loaded from nested pages.

---

### 🔧 What Was Done
- Updated `component-loader.js` to prevent prefixing absolute paths (starting with `/`).
- Ensured relative links are handled correctly across nested page structures.
- Verified consistent navigation between Home and About pages.

---

### ✅ Result
- Home → About works
- About → Home works
- Navigation is now consistent across all pages

---

This PR resolves #2061.