### PR TITLE
fix: resolve broken Emergency section links on localhost (#2066)

### DIFF
--- a/frontend/components/navbar.html
+++ b/frontend/components/navbar.html
@@ -183,15 +183,11 @@
                     Emergency <i class="fas fa-chevron-down arrow-icon"></i>
                 </button>
                 <ul class="dropdown">
-                    <li><a href="pages/report/sos.html">🆘 SOS Emergency</a></li>
-
-                    <li><a href="pages/report/report.html">Stray Pet</a></li>
-
-                    <li><a href="pages/report/report-dumping.html">Dumping Waste</a></li>
-
-                    <li><a href="pages/report/community-reporting.html">Community Reporting</a></li>
-
-                    <li><a href="pages/contact.html">Contact</a></li>
+                    <li><a href="/frontend/pages/report/sos.html">🆘 SOS Emergency</a></li>
+                    <li><a href="/frontend/pages/report/report.html">Stray Pet</a></li>
+                    <li><a href="/frontend/pages/report/report-dumping.html">Dumping Waste</a></li>
+                    <li><a href="/frontend/pages/report/community-reporting.html">Community Reporting</a></li>
+                    <li><a href="/frontend/pages/contact.html">Contact</a></li>
                 </ul>
             </li>
 


### PR DESCRIPTION
### Fix: Broken links in Emergency section on localhost

Updated the Emergency dropdown links in `frontend/components/navbar.html` to use root-based paths.

This resolves navigation issues occurring on localhost (port 5502) due to incorrect relative path usage.

Scope:
- Emergency section only
- No other navbar sections modified

All links were tested locally to ensure proper redirection.

Closes #2066