### PR TITLE
Fix: Make hero video background full screen and remove pause button #…

### DIFF
--- a/frontend/css/components/hero.css
+++ b/frontend/css/components/hero.css
@@ -10,6 +10,7 @@
 
 .hero-section {
   min-height: 100vh;
+  min-height: 100svh;
   background: var(--hero-bg-gradient);
   background-size: 200% 200%;
   background-attachment: fixed;
@@ -31,10 +32,16 @@
 }
 
 .hero-video-media {
+  position: absolute;
+  inset: 0;
   width: 100%;
   height: 100%;
+  min-width: 100%;
+  min-height: 100%;
   object-fit: cover;
+  object-position: center;
   filter: saturate(1.05);
+  display: block;
 }
 
 .hero-video-overlay {
@@ -43,37 +50,6 @@
   background: rgba(9, 24, 12, 0.45);
   z-index: 1;
   pointer-events: none;
-}
-
-.hero-video-toggle {
-  position: absolute;
-  right: 24px;
-  bottom: 24px;
-  z-index: 4;
-  display: inline-flex;
-  align-items: center;
-  gap: 10px;
-  padding: 10px 16px;
-  border-radius: 999px;
-  border: 1px solid rgba(255, 255, 255, 0.4);
-  background: rgba(15, 30, 18, 0.55);
-  color: #ffffff;
-  font-size: 0.9rem;
-  font-weight: 600;
-  cursor: pointer;
-  backdrop-filter: blur(8px);
-  transition: transform 0.2s ease, background 0.2s ease, border-color 0.2s ease;
-}
-
-.hero-video-toggle:hover,
-.hero-video-toggle:focus-visible {
-  background: rgba(15, 30, 18, 0.7);
-  border-color: rgba(255, 255, 255, 0.7);
-  transform: translateY(-2px);
-}
-
-.hero-video-toggle-text {
-  white-space: nowrap;
 }
 
 /* ===== ANIMATED BACKGROUND ===== */
@@ -569,10 +545,6 @@
 
 @media (prefers-reduced-motion: reduce) {
   .hero-video {
-    display: none;
-  }
-
-  .hero-video-toggle {
     display: none;
   }
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -241,15 +241,10 @@
         <video autoplay class="hero-video-media" id="hero-background-video" loop muted playsinline
           poster="assets/images/others/Animal_Environment_Photo.jpg">
           <source src="assets/videos/hero-background.mp4" type="video/mp4" />
-          <img alt="" src="assets/images/others/Animal_Environment_Photo.jpg" />
         </video>
       </div>
       <div aria-hidden="true" class="hero-video-overlay">
       </div>
-      <button aria-label="Pause background video" aria-pressed="true" class="hero-video-toggle" type="button">
-        <i class="fa-solid fa-pause"></i>
-        <span class="hero-video-toggle-text">Pause background video</span>
-      </button>
       <!-- Animated Background Elements -->
       <div aria-hidden="true" class="hero-bg-elements">
         <div class="floating-element leaf1">

--- a/frontend/js/pages/home.js
+++ b/frontend/js/pages/home.js
@@ -80,39 +80,26 @@ function initHeroParallax() {
 function initHeroVideoBackground() {
     const heroSection = document.querySelector('.hero-section');
     const video = document.getElementById('hero-background-video');
-    const toggleButton = document.querySelector('.hero-video-toggle');
 
-    if (!heroSection || !video || !toggleButton) {
+    if (!heroSection || !video) {
         return;
     }
 
-    const toggleLabel = toggleButton.querySelector('.hero-video-toggle-text');
-    const toggleIcon = toggleButton.querySelector('i');
     const prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)');
-
-    const updateToggleState = (isPlaying) => {
-        toggleButton.setAttribute('aria-pressed', String(isPlaying));
-        toggleButton.setAttribute('aria-label', isPlaying ? 'Pause background video' : 'Play background video');
-        if (toggleLabel) {
-            toggleLabel.textContent = isPlaying ? 'Pause background video' : 'Play background video';
-        }
-        if (toggleIcon) {
-            toggleIcon.className = isPlaying ? 'fa-solid fa-pause' : 'fa-solid fa-play';
-        }
-        heroSection.classList.toggle('video-paused', !isPlaying);
-    };
 
     const pauseVideo = () => {
         video.pause();
-        updateToggleState(false);
+        heroSection.classList.add('video-paused');
     };
 
     const playVideo = () => {
         const playPromise = video.play();
         if (playPromise && typeof playPromise.then === 'function') {
-            playPromise.then(() => updateToggleState(true)).catch(() => updateToggleState(false));
+            playPromise
+                .then(() => heroSection.classList.remove('video-paused'))
+                .catch(() => heroSection.classList.add('video-paused'));
         } else {
-            updateToggleState(!video.paused);
+            heroSection.classList.toggle('video-paused', video.paused);
         }
     };
 
@@ -121,14 +108,6 @@ function initHeroVideoBackground() {
     video.addEventListener('canplay', () => {
         heroSection.classList.add('video-ready');
     }, { once: true });
-
-    toggleButton.addEventListener('click', () => {
-        if (video.paused) {
-            playVideo();
-        } else {
-            pauseVideo();
-        }
-    });
 
     const handleMotionPreference = () => {
         if (prefersReducedMotion.matches) {


### PR DESCRIPTION
<img width="1897" height="972" alt="image" src="https://github.com/user-attachments/assets/5a4d8170-a1b6-4a7c-8bdc-1ef57a35702f" />
Fixes #2620: Make hero video background full screen

## Changes:
- Made background video fill entire viewport
- Removed pause button UI control
- Added proper fullscreen CSS (100svh + absolute positioning)
- Simplified video state management

## Testing:
- Video displays fullscreen on desktop/mobile
- Works with reduced-motion preferences
- No console errors