### PR TITLE
Fix: resolve Urban Green Finder broken links (#2611)

### DIFF
--- a/frontend/pages/education/urban/urban-tree-canopy-tracker.html
+++ b/frontend/pages/education/urban/urban-tree-canopy-tracker.html
@@ -14,7 +14,7 @@
     <nav>
       <ul>
         <li><a href="../../../index.html">Home</a></li>
-        <li><a href="../../urban-green-finder.html">Dashboard</a></li>
+        <li><a href="../../environment/urban-green-finder.html">Dashboard</a></li>
       </ul>
     </nav>
   </header>

--- a/frontend/pages/games/kids-zone.html
+++ b/frontend/pages/games/kids-zone.html
@@ -171,7 +171,7 @@
         <div class="card-emoji">🌳</div>
         <h3 class="card-title">Urban Green Finder</h3>
         <p class="card-description">Locate green spaces, parks, and nature spots in your city easily.</p>
-        <a href="../urban-green-finder.html" class="play-btn">
+        <a href="../environment/urban-green-finder.html" class="play-btn">
           <i class="fas fa-compass"></i> Explore
         </a>
       </div>


### PR DESCRIPTION

Fixed broken Urban Green Finder navigation links that were pointing to non-existent paths.
Updated links to the existing target page: urban-green-finder.html.
Files changed
kids-zone.html
urban-green-finder.html → urban-green-finder.html
urban-tree-canopy-tracker.html
urban-green-finder.html → urban-green-finder.html
Validation
Confirmed destination file exists.
Confirmed no stale broken link patterns remain in the repo for this path.
File-level checks reported no errors in modified files.