### PR TITLE
Fix #2586: Remove gap after closing crisis alerts and fix displaced f…

### DIFF
--- a/frontend/css/components/indigenous-crisis-alert.css
+++ b/frontend/css/components/indigenous-crisis-alert.css
@@ -252,6 +252,36 @@
   }
 }
 
+/* Navbar and main-content adjustment when indigenous crisis alert is shown */
+body.indigenous-crisis-alert-shown .navbar {
+  top: 80px;
+}
+
+body.indigenous-crisis-alert-shown #main-content {
+  margin-top: 80px;
+}
+
+/* Mobile responsiveness for layout adjustments */
+@media (max-width: 768px) {
+  body.indigenous-crisis-alert-shown .navbar {
+    top: 120px;
+  }
+
+  body.indigenous-crisis-alert-shown #main-content {
+    margin-top: 120px;
+  }
+}
+
+@media (max-width: 480px) {
+  body.indigenous-crisis-alert-shown .navbar {
+    top: 140px;
+  }
+
+  body.indigenous-crisis-alert-shown #main-content {
+    margin-top: 140px;
+  }
+}
+
 /* Reduced motion support */
 @media (prefers-reduced-motion: reduce) {
   .indigenous-crisis-alert-banner,

--- a/frontend/js/main.js
+++ b/frontend/js/main.js
@@ -1848,20 +1848,4 @@ function initFlipCards() {
 
 // ===========================================
 // END OF MAIN.JS
-// ===========================================function closeNoiseCrisisAlert() {
-function closeNoiseCrisisAlert() {
-  const banner = document.getElementById("noise-crisis-alert-banner");
-
-  if (banner) {
-    banner.style.display = "none";
-
-    // Move navbar to top after alert closes
-    const navbar = document.querySelector(".navbar");
-    if (navbar) {
-      navbar.style.top = "0px";
-    }
-
-    // Adjust body padding after alert removal
-    document.body.style.paddingTop = "80px";
-  }
-}
+// ===========================================


### PR DESCRIPTION
Fix #2586 — Homepage layout: gap after closing alerts & displaced feature

Problem
Two layout bugs on the homepage:

Large gap appeared after dismissing crisis alerts — A duplicate [closeNoiseCrisisAlert](vscode-file://vscode-app/c:/Users/91720/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html) function was appended after // END OF MAIN.JS which set [document.body.style.paddingTop = '80px'](vscode-file://vscode-app/c:/Users/91720/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html) as a permanent inline style without removing the noise-crisis-alert-shown body class, doubling the gap to ~160 px.
Feature/floating element displaced to top-left corner — The same duplicate function set navbar.style.top = '0px' but left the body class active, causing [#main-content](vscode-file://vscode-app/c:/Users/91720/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html) to shift down 80 px while the navbar sat at the top — pushing the hero's floating elements out of bounds.
Fix
[main.js](vscode-file://vscode-app/c:/Users/91720/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html) — Removed the rogue duplicate [closeNoiseCrisisAlert](vscode-file://vscode-app/c:/Users/91720/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html) function. The correct implementation using [NoiseCrisisAlertManager.dismissAlert()](vscode-file://vscode-app/c:/Users/91720/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html) is preserved; it properly removes the body class and cleans up all CSS layout adjustments on close.
[indigenous-crisis-alert.css](vscode-file://vscode-app/c:/Users/91720/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html) — Added missing [body.indigenous-crisis-alert-shown](vscode-file://vscode-app/c:/Users/91720/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html) CSS rules so the navbar and [#main-content](vscode-file://vscode-app/c:/Users/91720/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html) correctly adjust position when the indigenous-knowledge crisis alert is visible (consistent with the fire and noise alert stylesheets).
Closes #2586

<img width="1897" height="777" alt="image" src="https://github.com/user-attachments/assets/c7a281b4-21f0-47c7-ba03-e118f184e6a7" />
