### PR TITLE
Fix(#2661): Correct About Page Link Routing in Navbar

### DIFF
--- a/frontend/js/components/component-loader.js
+++ b/frontend/js/components/component-loader.js
@@ -19,16 +19,20 @@
     function getRelativePrefix() {
     const path = window.location.pathname;
 
+    // If inside frontend/pages/
     if (path.includes('/frontend/pages/')) {
-        const parts = path.split('/');
-        const pagesIndex = parts.indexOf('pages');
-        const depth = parts.length - pagesIndex - 2;
+        const afterPages = path.split('/frontend/pages/')[1];
 
-        if (depth >= 2) return '../../';
+        // If nested (example: pages/community/donation.html)
+        if (afterPages.includes('/')) {
+            return '../../';
+        }
+
+        // Direct page like pages/about.html
         return '../';
     }
 
-    // If we are directly inside /frontend/
+    // If inside frontend root (index.html)
     if (path.includes('/frontend/')) {
         return '';
     }


### PR DESCRIPTION
## 🔧 Fix Broken "About" Page Link in Navbar (#2661)

### 📌 Description
This PR fixes inconsistent routing behavior of the "About" link in the navbar.

Previously, navigation could break or produce 404 errors when accessed from:
- Nested `/pages/` directories
- Subfolders such as `/pages/community/`
- Localhost (port 5502)
- GitHub Pages deployment

### 🚨 Root Cause
The relative path prefix logic did not correctly account for nested directory depth inside `/frontend/pages/`.

### 🛠 Changes Made
- Updated `getRelativePrefix()` in `component-loader.js`
- Standardized path handling for:
  - Root pages
  - Direct `/pages/` files
  - Nested subdirectories
- Ensured compatibility with:
  - Localhost (port 5502)
  - GitHub Pages
  - All internal navigation

### ✅ Tested On
- `frontend/index.html`
- `frontend/pages/about.html`
- `frontend/pages/community/index.html`
- `frontend/pages/community/donation.html`

Navigation works correctly from all levels.
No 404 errors.
No absolute path usage.

### 📦 Impact
Improves navigation reliability and ensures consistent routing behavior across the project.

## Closes #2661 