### PR TITLE
Fix: UI Fix Remove Emergency Alert From Navbar Area #3176

### DIFF
--- a/frontend/css/components/noise-crisis-alert.css
+++ b/frontend/css/components/noise-crisis-alert.css
@@ -1,39 +1,81 @@
 /* Noise Pollution Crisis Alert Banner - Level 3 Emergency Styling */
 
 @keyframes wavePulse {
-  0%, 50%, 100% { transform: scale(1) rotate(0deg); opacity: 1; }
-  25% { transform: scale(1.1) rotate(2deg); opacity: 0.9; }
-  50% { transform: scale(0.95) rotate(-2deg); opacity: 0.95; }
-  75% { transform: scale(1.02) rotate(1deg); opacity: 0.9; }
+
+  0%,
+  50%,
+  100% {
+    transform: scale(1) rotate(0deg);
+    opacity: 1;
+  }
+
+  25% {
+    transform: scale(1.1) rotate(2deg);
+    opacity: 0.9;
+  }
+
+  50% {
+    transform: scale(0.95) rotate(-2deg);
+    opacity: 0.95;
+  }
+
+  75% {
+    transform: scale(1.02) rotate(1deg);
+    opacity: 0.9;
+  }
 }
 
 @keyframes waveDistortion {
-  0% { background-position: 0% 50%; }
-  50% { background-position: 100% 50%; }
-  100% { background-position: 0% 50%; }
+  0% {
+    background-position: 0% 50%;
+  }
+
+  50% {
+    background-position: 100% 50%;
+  }
+
+  100% {
+    background-position: 0% 50%;
+  }
 }
 
 @keyframes soundRipple {
-  0% { transform: scale(0); opacity: 1; }
-  50% { transform: scale(1); opacity: 0.7; }
-  100% { transform: scale(2); opacity: 0; }
+  0% {
+    transform: scale(0);
+    opacity: 1;
+  }
+
+  50% {
+    transform: scale(1);
+    opacity: 0.7;
+  }
+
+  100% {
+    transform: scale(2);
+    opacity: 0;
+  }
 }
 
 .noise-crisis-alert-banner {
   position: fixed;
-  top: 0;
-  left: 0;
-  width: 100%;
+  bottom: 20px;
+  right: 20px;
+  top: auto;
+  left: auto;
+  width: auto;
+  max-width: 450px;
+  border-radius: 12px;
   background: linear-gradient(135deg, #1a1a2e 0%, #16213e 50%, #0f3460 100%);
   background-size: 400% 400%;
   animation: waveDistortion 6s ease-in-out infinite, wavePulse 4s infinite;
   z-index: 2000;
   border-bottom: 3px solid #0080ff;
+  border: 1px solid rgba(0, 128, 255, 0.4);
   box-shadow: 0 5px 25px rgba(0, 128, 255, 0.6);
 }
 
 .noise-crisis-alert-banner.closing {
-  animation: slideUp 0.5s ease-in forwards;
+  animation: slideDown 0.5s ease-in forwards;
 }
 
 .noise-crisis-alert-content {
@@ -135,14 +177,7 @@
   border-color: rgba(255, 255, 255, 0.8);
 }
 
-/* Navbar adjustment when crisis alert is shown */
-body.noise-crisis-alert-shown .navbar {
-  top: 80px;
-}
-
-body.noise-crisis-alert-shown #main-content {
-  margin-top: 80px;
-}
+/* Navbar adjustment removed as it is now floating */
 
 /* Mobile responsiveness */
 @media (max-width: 768px) {
@@ -174,13 +209,7 @@ body.noise-crisis-alert-shown #main-content {
     font-size: 0.8rem;
   }
 
-  body.noise-crisis-alert-shown .navbar {
-    top: 120px;
-  }
 
-  body.noise-crisis-alert-shown #main-content {
-    margin-top: 120px;
-  }
 }
 
 @media (max-width: 480px) {
@@ -199,13 +228,7 @@ body.noise-crisis-alert-shown #main-content {
     justify-content: center;
   }
 
-  body.noise-crisis-alert-shown .navbar {
-    top: 140px;
-  }
 
-  body.noise-crisis-alert-shown #main-content {
-    margin-top: 140px;
-  }
 }
 
 /* Additional urgency animations for Level 3 */


### PR DESCRIPTION
<img width="1901" height="966" alt="image" src="https://github.com/user-attachments/assets/f54e0418-10f5-466d-a69e-c8491e943322" />
**Problem:** 
The emergency alert banner was currently displayed above the navbar. It overlapped the navigation bar and affected the layout and user experience. Navbar visibility was reduced, UI looked cluttered, and the responsive layout could break on smaller screens. 

**Expected Behavior:** 
The emergency alert should not overlap the navbar. 

**Changes made:** 
I changed the CSS for the Noise Crisis Alert to make it a dismissible floating notification in the bottom right corner of the screen. This fixes the navbar overlap issue and provides a much cleaner user experience.

Resolves #3176 
