### PR TITLE
Fix: Dark Mode Quiz Option Text Visibility (#3163)

### DIFF
--- a/frontend/css/components/quiz.css
+++ b/frontend/css/components/quiz.css
@@ -618,7 +618,7 @@ footer {
   .quiz-floating-badge {
     display: none;
   }
-}
+
 /* High-Quality Card Styling */
 .quiz-feature {
   background: #ffffff;
@@ -991,6 +991,7 @@ button {
 
 .option {
     background: #f1f8e9;
+    color: #1a1a1a;
     padding: 18px 25px;
     border-radius: 18px;
     cursor: pointer;
@@ -1347,4 +1348,20 @@ button {
 @media (max-width: 600px) {
     .sun { width: 100px; height: 100px; top: -30px; right: -30px; }
     .hero { padding-bottom: 120px; }
+}
+/* Dark Mode Fix for Quiz Options */
+
+body.dark-mode .option {
+    background: #2b2b2b;
+    color: #ffffff;
+    border: 2px solid rgba(255,255,255,0.15);
+}
+
+body.dark-mode .option:hover {
+    background: #3a3a3a;
+}
+
+body.dark-mode .option.selected {
+    background: var(--green);
+    color: #ffffff;
 }


### PR DESCRIPTION
This PR fixes the dark mode readability issue in the Climate Quiz Battle (#3163).

### Changes Made

* Added explicit text color for quiz option buttons
* Implemented dark mode specific styles for quiz options
* Improved contrast between text and background
* Ensured better readability and accessibility

### Result

Quiz option text is now clearly visible in dark mode with improved contrast and consistent UI behavior.

Closes #3163 
