### PR TITLE
Fix: Make Full Image Visible and Adjust Card Size (#3205)

### DIFF
--- a/frontend/css/components/card.css
+++ b/frontend/css/components/card.css
@@ -56,11 +56,20 @@
 /* Card Image */
 .card-image {
   position: relative;
-  height: 250px;
+  height: auto;
+  max-height: 320px;
   overflow: hidden;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
 .card-image img {
+  width: 100%;
+  height: auto;
+  max-height: 320px;
+  object-fit: contain;
+  display: block;
   transition: transform 0.6s ease;
 }
 


### PR DESCRIPTION
This PR fixes the issue where feature card images were partially cropped.

Changes made:

* Updated `.card-image` container to allow flexible height
* Added `object-fit: contain` for full image visibility
* Adjusted image scaling for responsive behavior
* Maintained existing hover animation

Result:
Images inside feature cards are now fully visible and the card layout adapts correctly.

<img width="1919" height="1010" alt="image" src="https://github.com/user-attachments/assets/81b8a1f2-b2d4-4463-8b17-ffccde25012a" />

Closes #3205 
