### PR TITLE
Community dropdown

### DIFF
--- a/frontend/components/navbar.html
+++ b/frontend/components/navbar.html
@@ -61,11 +61,23 @@
       </li>
 
       <!-- Community -->
-      <li class="nav-group">
-        <a href="pages/community/index.html" class="nav-link">
-          Community
-        </a>
-      </li>
+     <li class="nav-group has-submenu">
+ <button type="button" class="nav-link submenu-toggle">
+          Community <i class="fas fa-chevron-down arrow-icon"></i>
+        </button>
+
+  <ul class="dropdown">
+    <li><a href="pages/community/community-action-hub.html">Community Action Hub</a></li>
+    <li><a href="pages/community/community-air-quality-monitor.html">Community Air Quality</a></li>
+    <li><a href="pages/community/community-cleanup-events.html">Air Cleanup Event</a></li>
+    <li><a href="pages/community/community-education.html">Community Education</a></li>
+    <li><a href="pages/community/community-energy-monitor.html">Energy Monitor</a></li>
+    <li><a href="pages/community/community-garden-board.html">Garden Board</a></li>
+    <li><a href="pages/community/community-garden-locator.html">Garden Locator</a></li>
+    <li><a href="pages/community/community-renewable-energy-dashboard.html">Renewable Energy Dashboard</a></li>
+    <li><a href="pages/community/community-renewable-energy-tracker.html">Renewable Energy Tracker</a></li>
+  </ul>
+</li>
 
       <!-- Eco Hub -->
       <li class="nav-group">


### PR DESCRIPTION
**PR Description:**

Added a **dropdown menu for the Community section in the navbar** to organize multiple community-related pages under a single navigation item. Previously, users could only access the main Community page, but now they can directly navigate to specific community features from the dropdown.

The dropdown includes links to pages such as **Community Action Hub, Air Quality, Air Cleanup Event, Community Education, Energy Monitor, Garden Board, Garden Locator, Renewable Energy Dashboard, and Renewable Energy Tracker**. This improves navigation and makes it easier for users to access different community tools and initiatives without extra steps.

**Impact:**

* Improved navbar navigation and structure
* Faster access to all community-related pages
* Better user experience by grouping related features under one menu

**Close #3208**

ss:

<img width="1365" height="580" alt="image" src="https://github.com/user-attachments/assets/c43d50bc-74ec-45d5-b8f0-c1aff984e6a1" />

`Note: Every link in community dropdown is working i checked it with myself`
