### PR TITLE
Added navbar and improved its styling on ecohub page

### DIFF
--- a/frontend/css/components/interactive-elements.css
+++ b/frontend/css/components/interactive-elements.css
@@ -224,6 +224,8 @@ a:hover {
 /* Navigation Links */
 nav a,
 .nav-link {
+  background: transparent;
+    color: var(--navbar-text);
   padding: 12px 16px;
   min-height: 44px;
   display: flex;

--- a/frontend/pages/games/kids-zone.html
+++ b/frontend/pages/games/kids-zone.html
@@ -7,12 +7,15 @@
   <link rel="icon" type="image/png" href="/envirnoment-logo.png" />
 
   <!-- global & variables (original) -->
-  <link rel="stylesheet" href="css/global/utilities.css" />
-  <link rel="stylesheet" href="../../css/global/variables.css" />
+     <link rel="stylesheet" href="../../css/global/variables.css" />
+  <link rel="stylesheet" href="../../css/global/utilities.css" />
+
   <link rel="stylesheet" href="../../css/components/card.css" />
-  <link rel="stylesheet" href="../../css/components/navbar.css" />
+  <link rel="stylesheet" href="../../css/components/navbar.css"/>
+  <link rel="stylesheet" href="../../css/components/interactive-elements.css" />
   <link rel="stylesheet" href="../../css/components/footer.css" />
-  <link rel="stylesheet" href="../../css/pages/games/kids-zone.css" />
+  <link rel="stylesheet" href="../../css/pages/games/kids-zone.css"/>
+   <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" rel="stylesheet" />
 
   <!-- AOS & Font Awesome -->
   <link href="https://unpkg.com/aos@2.3.1/dist/aos.css" rel="stylesheet" />
@@ -248,9 +251,11 @@
 </head>
 
 <body>
+ 
 
   <div id="cursor-container"></div>
-  <script src="../../js/components/loadComponents.js"></script>
+  <div id="navbar-container"></div>
+  
 
   <!-- Background Particles -->
   <div class="bg-particles" id="particles"></div>
@@ -262,23 +267,11 @@
   </button>
 
   <!-- Breadcrumb -->
-  <nav>
-    <div>
-      <div id="navbar-container"></div>
-    </div>
-  </nav>
 
   <!-- Header -->
   <header class="page-header">
     <!-- Breadcrumb -->
-    <nav class="breadcrumb">
-      <a href="../../index.html">
-        <i class="fas fa-home"></i>
-        Home
-      </a>
-      <span>/</span>
-      <span>Kids Zone</span>
-    </nav>
+    
     <div class="header-content">
       <h1 style="padding-top: 65px;">🌱 EcoLife Kids Zone</h1>
       <p class="tagline">Where learning meets fun, and sustainability becomes a game!</p>
@@ -1378,6 +1371,6 @@
       });
     })();
   </script>
-  
+  <script src="../../js/components/component-loader.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## issue #3234 

Rationale for this change

The background of three navbar buttons (including dropdown buttons) was appearing white due to default browser styling being applied instead of the intended project styles. This caused inconsistency in the navbar appearance and reduced visual clarity. To ensure consistent styling across the navbar, a background color was explicitly added.

What changes are included in this PR?

Added a background color to the .nav-links interactive element in the CSS.
This overrides the default browser styling that was previously affecting the buttons.
Ensures the three dropdown buttons visually align with the rest of the navbar design.

Are these changes tested?

Yes.
The changes were tested locally by running the project and verifying that the navbar buttons now display the correct background color and maintain consistent styling across the page.

Are there any user-facing changes?

Yes.
The navbar buttons now have a consistent background color, improving visibility and overall UI consistency.

Screenshots (if Applicable)

Before: There was no navbar and even after adding that the text was not visible 
No navbar
<img width="1912" height="1074" alt="Screenshot 2026-03-06 133214" src="https://github.com/user-attachments/assets/2ccfafc3-9d60-4484-a1dd-dd14d9bc85d2" />

after adding navbar text was not visible:
<img width="1907" height="1027" alt="Screenshot 2026-03-06 204347" src="https://github.com/user-attachments/assets/06dce4ae-cf79-4d75-b6e4-ff89e11efc12" />

After: The navbar is added and  buttons  match the navbar styling with the correct background color applied.
<img width="1915" height="994" alt="image" src="https://github.com/user-attachments/assets/1e532c8a-77cb-4676-933c-53b4aebebb4f" />

