### PR TITLE
the text on eco hub page is  visible in both theme

### DIFF
--- a/frontend/css/pages/games/kids-zone.css
+++ b/frontend/css/pages/games/kids-zone.css
@@ -244,7 +244,7 @@
     .games-grid h2 {
       font-size: 2rem;
       font-weight: 700;
-      color: var(--text-primary);
+      color: var(--primary-dark);
       margin-left: 40px;
     }
     .learning-section, .quiz-section, .game-section {


### PR DESCRIPTION


Closes #3236 

Rationale for this change

The text "Learning Adventure, Quiz Challenges, Fun Games" was not visible when the website was viewed in light theme. This occurred because the text color blended with the light background, making it difficult or impossible for users to read.
To improve readability and ensure a consistent user experience across themes, the text styling has been updated so that it remains clearly visible in both light and dark modes.

What changes are included in this PR?

1. Updated the CSS styling for the text "Learning Adventure, Quiz Challenges, Fun Games".
2. Adjusted the color properties to ensure proper contrast in light theme.
3. Ensured the text remains readable and visually consistent in both light and dark themes.
4. Maintained the existing layout and design without affecting other components of the page.

Are these changes tested?

Yes
. The changes were tested locally by switching between light mode and dark mode in the browser.
The text is now clearly visible and readable in both themes without affecting the layout or other UI elements.

Are there any user-facing changes?

Yes.

Users can now clearly see the text "Learning Adventure, Quiz Challenges, Fun Games" in light theme, which improves readability and overall user experience.

Screenshots 
Before Fix:
Text was not visible in light theme due to poor contrast with the background.
<img width="1907" height="1027" alt="Screenshot 2026-03-06 204347" src="https://github.com/user-attachments/assets/104f10e4-1358-406f-bc61-e16d98ef6ad8" />


After Fix:
Text is now clearly visible and readable in both light and dark themes.
<img width="1908" height="754" alt="Screenshot 2026-03-07 091139" src="https://github.com/user-attachments/assets/c7ccc3d7-bbdf-4eaa-9af1-273ee0d64878" />
<img width="1910" height="596" alt="Screenshot 2026-03-07 091130" src="https://github.com/user-attachments/assets/4de0142f-b5a1-43a5-9b66-5da119472463" />
<img width="1907" height="818" alt="Screenshot 2026-03-07 091118" src="https://github.com/user-attachments/assets/aab265ba-5470-40ac-b633-8b2021699003" />

